### PR TITLE
adding feature to recover from crash during (un)load selection screen

### DIFF
--- a/app/current_move_frame.py
+++ b/app/current_move_frame.py
@@ -49,6 +49,6 @@ class CurrentMoveFrame:
         if self.current_move_number < self.total_moves:
             next_button = tk.Button(move_info_frame, text="Next", font=("Arial", 16), padx=10, pady=10, command=lambda: self.create_current_move_frame())
         else:
-            next_button = tk.Button(move_info_frame, text="Done", font=("Arial", 16), padx=10, pady=10, command=lambda: self.finish_move(self.frame.master, self.frame))
+            next_button = tk.Button(move_info_frame, text="Done", font=("Arial", 16), padx=10, pady=10, command=lambda: [self.finish_move(self.frame.master, self.frame), delete_save_file()])
         
         next_button.pack(pady=10)

--- a/app/operations.py
+++ b/app/operations.py
@@ -25,17 +25,24 @@ def display_operations(root, selection):
     
     ordered_list = []
     
+    # read from file if data is found add items else it is empty
+    ordered_list = read_save_file("ordered_list")
+    container_list = read_save_file("container_list")   
+    
     def update_list():
         container_listbox.delete(0, tk.END)  # Clear existing items
         for operation, value in ordered_list:
             container_listbox.insert(tk.END, f"{operation}: {value}")
             
+        # Update data in the save file
+        write_save_file("ordered_list", ordered_list)
+        write_save_file("container_list", container_list)  
         
     def add_container(name, container_input):
         if name == '':
             return
         container_list["Load"].append(name)
-        ordered_list.append(("Load", name))
+        ordered_list.append(("Load", name))        
         container_input.delete(0, tk.END)
         update_list()
 
@@ -45,6 +52,9 @@ def display_operations(root, selection):
         else:
             operations_screen(root, load_unload_frame)
 
+    # save current state for crash recovery
+    write_save_file("state", 1)
+    
     # parent frame of the page
     load_unload_frame = tk.Frame(root)
     load_unload_frame.pack(expand=1, fill="both")
@@ -86,7 +96,7 @@ def display_operations(root, selection):
     
     hover_label = tk.Label(load_unload_frame, bg="yellow", text="", font=("Arial", 12), relief="solid", borderwidth=1)
 
-
+    
     # display the ship's current cargo
     display_current_cargo(cargo_frame, get_manifest(), container_list, hover_label, update_list, ordered_list)
     #ship_table = Table(cargo_frame, get_manifest())
@@ -98,12 +108,12 @@ def darkenCell(label, container_list, name, update_list, ordered_list):
         label.config(bg="SystemButtonFace")
         if name in container_list["Unload"]:
             container_list["Unload"].remove(name)
-            ordered_list.remove(("Unload", name))
+            ordered_list.remove(["Unload", name])
             update_list()
     else:
         label.config(bg="red")
         container_list["Unload"].append(name)
-        ordered_list.append(("Unload", name))
+        ordered_list.append(["Unload", name])
         update_list()
 
 #def operations_screen(root,frame1):
@@ -124,6 +134,9 @@ def display_current_cargo(frame, current_cargo, container_list, hover_label, upd
             else:
                 cell = tk.Label(frame, text=truncated_value, borderwidth=1, relief="solid", width=7, height=2, font=("Arial", 12), anchor="center")
             cell.grid(row=i, column=j, sticky="nsew")
+            
+            recover_darkenCells(cell, truncated_value, update_list)
+            
             if not(truncated_value == "UNUSED" or truncated_value == "NAN"):
                 cell.bind("<Button 1>",lambda event, name=truncated_value,label=cell:[darkenCell(label, container_list, name, update_list, ordered_list)])
                 cell.bind("<Enter>", lambda event, row=i, col=j,current_cargo=current_cargo,hover_label=hover_label:show_hover_label(event, row, col,current_cargo,hover_label))
@@ -149,7 +162,14 @@ def hide_hover_label(event,hover_label):
         if hover_label.winfo_exists():
             hover_label.place_forget()
 
-
+def recover_darkenCells(cell, truncated_value, update_list):
+        saved_list = read_save_file("ordered_list")
+        r = len(saved_list)
+        for k in range(r):
+            if truncated_value == saved_list[k][1]:
+                cell.config(bg="red")
+                update_list()
+    
 
 # display_operations(root)
 # root.geometry("800x600")

--- a/app/operations_screen.py
+++ b/app/operations_screen.py
@@ -7,11 +7,13 @@ from app.current_move_frame import CurrentMoveFrame
 from config import *
 
 def operations_screen(root, prevFrame):
-
     buffer_data = [[(0, "UNUSED") for _ in range(24)] for _ in range(4)]
 
     # destroys previous frame
     prevFrame.pack_forget()
+    
+    # save current state for crash recovery 
+    # write_save_file("state", 2)
 
     # create operations screen frame
     operations_screen_frame = tk.Frame(root)

--- a/app/tempCodeRunnerFile.py
+++ b/app/tempCodeRunnerFile.py
@@ -1,0 +1,1 @@
+# save current state for crash recovery

--- a/config.py
+++ b/config.py
@@ -1,7 +1,7 @@
 # global functions for easy access from all files
 # to access from the app folder do: from config import *
 
-import requests, json
+import requests, json, os
 
 def set_logfile_path(path):
     global logfile_path
@@ -27,9 +27,15 @@ def get_username():
 def set_manifest(data):
     global manifest_data
     manifest_data = data
+    write_save_file("manifest_data", data)
 
 def get_manifest():
-    return manifest_data
+    # retrieve data during runtime
+    #return manifest_data 
+    
+    # retrieve data from save file
+    return read_save_file("manifest_data")
+
 
 def set_move_info(total_moves, total_minutes, current_move_number, current_move_from, current_move_to, estimated_time_for_move):
     """
@@ -48,6 +54,10 @@ def set_move_info(total_moves, total_minutes, current_move_number, current_move_
         f"Move from {current_move_from} to {current_move_to}, "
         f"estimated: {estimated_time_for_move} minutes."
     )
+    
+    # Store changes per move - TEMP
+    # with open(get_save_file_path(), 'a') as json_file:
+    #         json.dump(move_data, json_file, indent=4)
 
 def get_move_info():
     return move_info
@@ -107,3 +117,7 @@ def read_save_file(key):
         entry = ""
         
     return entry
+
+def delete_save_file():
+    if os.path.exists(save_file_path):
+        os.remove(save_file_path)

--- a/main.py
+++ b/main.py
@@ -3,12 +3,28 @@ from app import *
 from tkinter import Tk
 from config import *
 from app.login import login_screen
+from app.operations import *
 
 def create_root():
     root = Tk()
     root.title("CargoSail Solutions")
     root.geometry("1400x800")
     return root
+
+def crash_recovery(root, state):
+    temp = Frame(root) 
+    
+    match state:
+        case 1:
+            # Go to (un)load selection screen
+            display_operations(root, temp)
+        case 2:
+            # Go to operation screen for (un)load or balance
+            print("operations for load/unload or balance")
+        case _:
+            # Default: Start at the login screen
+            login_screen(root)
+
 
 def open_logfile_and_save():
     # find localappdata directory
@@ -31,7 +47,14 @@ def open_logfile_and_save():
     # if the save file is not created yet it will create it with the fields specified here
     if not os.path.exists(save_file_path):
         data = {
-            "name": ""
+            "name": "",
+            "state" : "", # 1 = unload/load selection, 2 = operations
+            "ordered_list" : [],
+            "container_list": {
+                "Unload": [],
+                "Load": []
+            },
+            "manifest_data": []
         }
         
         with open(save_file_path, 'w') as json_file:
@@ -39,6 +62,8 @@ def open_logfile_and_save():
 
 root = create_root()
 open_logfile_and_save()
-login_screen(root)
+
+last_state = read_save_file("state")
+crash_recovery(root, last_state)
 
 root.mainloop()

--- a/tempCodeRunnerFile.py
+++ b/tempCodeRunnerFile.py
@@ -1,0 +1,1 @@
+save_file_path


### PR DESCRIPTION
crash recovery currently works only for the unload/load selection screen
* program now saves data that user has inputted such as manifest file, container list, ordered list
* when crash happens, user will return to unload/load selection screen where they left off

quick fix
* save_file.json is deleted once container moves are completed on ship